### PR TITLE
Fix issue with babel-loader messing up source map

### DIFF
--- a/client/webpack.config.devel.js
+++ b/client/webpack.config.devel.js
@@ -14,4 +14,14 @@ develop.output.devtoolLineToLine = true;
 develop.output.pathinfo = true;
 develop.output.sourceMapFilename = '[name].bundle.js.map';
 
+// fix issue with babel-loader messing up source map
+develop.module.loaders =
+    develop.module.loaders
+    .filter(obj => obj.loader === 'babel-loader')
+    .map((obj) => {
+        const newLoader = Object.assign({}, obj);
+        newLoader.query.retainLines = true;
+        return newLoader;
+    });
+
 module.exports = develop;


### PR DESCRIPTION
This PR makes babel retain line numbers in the development build so that they correspond to what's in the source map.