### PR TITLE
Change eslint rule indent to 4 spaces

### DIFF
--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -1,3 +1,6 @@
 {
-  'extends': 'airbnb',
+    extends: 'airbnb',
+    rules: {
+        indent: ['error', 4],
+    },
 }

--- a/client/webpack.config.dist.js
+++ b/client/webpack.config.dist.js
@@ -1,29 +1,29 @@
 const path = require('path');
 
 const distribute = {
-  context: __dirname,
-  entry: {
-    main: ['babel-polyfill', './src/js/main.controller.js'],
-  },
-  output: {
-    path: path.join(__dirname, 'dist/'),
-    filename: '[name].bundle.js',
-  },
-  externals: {
-    angular: 'angular',
-    jquery: 'jquery',
-    toastr: 'toastr',
-  },
-  module: {
-    loaders: [{
-      loader: 'babel-loader',
-      include: path.join(__dirname, 'src/'),
-      test: /\.js$/,
-      query: {
-        presets: ['es2015'],
-      },
-    }],
-  },
+    context: __dirname,
+    entry: {
+        main: ['babel-polyfill', './src/js/main.controller.js'],
+    },
+    output: {
+        path: path.join(__dirname, 'dist/'),
+        filename: '[name].bundle.js',
+    },
+    externals: {
+        angular: 'angular',
+        jquery: 'jquery',
+        toastr: 'toastr',
+    },
+    module: {
+        loaders: [{
+            loader: 'babel-loader',
+            include: path.join(__dirname, 'src/'),
+            test: /\.js$/,
+            query: {
+                presets: ['es2015'],
+            },
+        }],
+    },
 };
 
 module.exports = distribute;


### PR DESCRIPTION
This PR changes the eslint rule 'indent' from 2 spaces (according to the airbnb style guide) to 4 spaces, which better fits the current style of the repo.