### PR TITLE
Add jsdoc module and make target

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -2,6 +2,7 @@ SRC_DIR = src
 DEVEL_DIR = devel
 DISTR_DIR = dist
 NODE_DIR = ./node_modules/.bin
+DOC_DIR = ./doc
 
 DEVEL ?= 0
 ifeq ($(DEVEL), 1)
@@ -16,10 +17,15 @@ all: \
 	$(shell find $(SRC_DIR) -type f | grep -e \.html$ | sed -r 's/^$(SRC_DIR)/$(BIN_DIR)/') \
 	$(shell find $(SRC_DIR) -type f | grep -e \.png$ | sed -r 's/^$(SRC_DIR)/$(BIN_DIR)/') \
 	$(BIN_DIR)/stylesheet.css \
-	$(BIN_DIR)/main.bundle.js
+	$(BIN_DIR)/main.bundle.js \
+	$(DOC_DIR)/index.html
 
 clean:
 	rm -fr $(BIN_DIR)/*
+	rm -fr $(DOC_DIR)
+
+$(DOC_DIR)/index.html: $(shell find $(SRC_DIR) -type f | grep -e \.js$ )
+	$(NODE_DIR)/jsdoc $(SRC_DIR) -r -d $(DOC_DIR) -c ./jsdoc.conf.json
 
 $(DISTR_DIR)/%.html: $(SRC_DIR)/%.html
 	mkdir -p `dirname $@`

--- a/client/jsdoc.conf.json
+++ b/client/jsdoc.conf.json
@@ -1,0 +1,15 @@
+{
+    "tags": {
+        "allowUnknownTags": true,
+        "dictionaries": ["jsdoc", "closure"]
+    },
+    "source": {
+        "includePattern": ".+\\.js(doc|x)?$",
+        "excludePattern": "(^|\\/|\\\\)_"
+    },
+    "plugins": ["plugins/markdown"],
+    "templates": {
+        "cleverLinks": false,
+        "monospaceLinks": false
+    }
+}

--- a/client/package.json
+++ b/client/package.json
@@ -13,6 +13,7 @@
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-react": "^6.10.3",
     "html-minifier": "^3.4.2",
+    "jsdoc": "^3.4.3",
     "uglify-js": "^2.8.21",
     "webpack": "^2.3.3"
   },


### PR DESCRIPTION
This PR adds a documentation target in the makefile. The docs are compiled using jsdoc.